### PR TITLE
Auto complete search

### DIFF
--- a/api/analysis.py
+++ b/api/analysis.py
@@ -139,7 +139,7 @@ def get_cached_names():
   db = mongo_client.ArquivoSentimentos
 
   query = {"name": { "$exists": True}}
-  fields = { "name": 1, "_id": 0 }
+  fields = { "name": 1, "_id": 0}
 
   docs = db.ArquivoSentimentos.find(query, fields)
 
@@ -147,5 +147,9 @@ def get_cached_names():
   for doc in docs:
     cached_names.add(doc["name"])
 
-  return list(cached_names)
+  cached_names_list = []
+  for name in cached_names:
+    cached_names_list.append({"name": name})
+
+  return cached_names_list
 

--- a/api/analysis.py
+++ b/api/analysis.py
@@ -14,103 +14,15 @@ from bson.objectid import ObjectId
 sources_urls = {'Correio da Manhã': 'www.cmjornal.pt', 'Jornal de Notícias': 'www.jn.pt', 'Público': 'www.publico.pt'}
 
 
-def analyze_entities(text_content):
-    """
-    Analyzing Entities in a String
-
-    Args:
-      text_content The text content to analyze
-    """
-
-    client = language_v1.LanguageServiceClient()
-
-    # Available types: PLAIN_TEXT, HTML
-    type_ = language_v1.Document.Type.PLAIN_TEXT
-
-    # Optional. If not specified, the language is automatically detected.
-    # For list of supported languages:
-    # https://cloud.google.com/natural-language/docs/languages
-    language = "en"
-    document = {"content": text_content, "type_": type_, "language": language}
-
-    # Available values: NONE, UTF8, UTF16, UTF32
-    encoding_type = language_v1.EncodingType.UTF8
-
-    response = client.analyze_entities(request = {'document': document, 'encoding_type': encoding_type})
-
-    # Loop through entitites returned from the API
-    for entity in response.entities:
-        print(u"Representative name for the entity: {}".format(entity.name))
-
-        # Get entity type, e.g. PERSON, LOCATION, ADDRESS, NUMBER, et al
-        print(u"Entity type: {}".format(language_v1.Entity.Type(entity.type_).name))
-
-        # Get the salience score associated with the entity in the [0, 1.0] range
-        print(u"Salience score: {}".format(entity.salience))
-
-        # Loop over the metadata associated with entity. For many known entities,
-        # the metadata is a Wikipedia URL (wikipedia_url) and Knowledge Graph MID (mid).
-        # Some entity types may have additional metadata, e.g. ADDRESS entities
-        # may have metadata for the address street_name, postal_code, et al.
-        for metadata_name, metadata_value in entity.metadata.items():
-            print(u"{}: {}".format(metadata_name, metadata_value))
-
-        # Loop over the mentions of this entity in the input document.
-        # The API currently supports proper noun mentions.
-        for mention in entity.mentions:
-            print(u"Mention text: {}".format(mention.text.content))
-
-            # Get the mention type, e.g. PROPER for proper noun
-            print(
-                u"Mention type: {}".format(language_v1.EntityMention.Type(mention.type_).name)
-            )
-
-    # Get the language of the text, which will be the same as
-    # the language specified in the request or, if not specified,
-    # the automatically-detected language.
-    print(u"Language of the text: {}".format(response.language))
-
 
 def analyze_sentiment(text_content):
-    """
-    Analyzing Sentiment in a String
-
-    Args:
-      text_content The text content to analyze
-    """
-
     client = language_v1.LanguageServiceClient()
-
-    # Available types: PLAIN_TEXT, HTML
     type_ = language_v1.Document.Type.PLAIN_TEXT
-
-    # Optional. If not specified, the language is automatically detected.
-    # For list of supported languages:
-    # https://cloud.google.com/natural-language/docs/languages
     language = "pt"
     document = {"content": text_content, "type_": type_, "language": language}
-
-    # Available values: NONE, UTF8, UTF16, UTF32
     encoding_type = language_v1.EncodingType.UTF8
 
     response = client.analyze_sentiment(request = {'document': document, 'encoding_type': encoding_type})
-    # Get overall sentiment of the input document
-    # print(u"Document sentiment score: {}".format(response.document_sentiment.score))
-    # print(
-    #     u"Document sentiment magnitude: {}".format(
-    #         response.document_sentiment.magnitude
-    #     )
-    # )
-    # Get sentiment for all sentences in the document
-    # for sentence in response.sentences:
-        # print(u"Sentence text: {}".format(sentence.text.content))
-        # print(u"Sentence sentiment score: {}".format(sentence.sentiment.score))
-        # print(u"Sentence sentiment magnitude: {}".format(sentence.sentiment.magnitude))
-
-    # Get the language of the text, which will be the same as
-    # the language specified in the request or, if not specified,
-    # the automatically-detected language.
-    # print(u"Language of the text: {}".format(response.language))
     return response.document_sentiment.score, response.document_sentiment.magnitude
 
 
@@ -125,7 +37,6 @@ def fetch_link_preview(website, link):
   link_description = soup.select_one('meta[property="og:description"]')
   link_site_name = soup.select_one('meta[property="og:site_name"]')
   link_image = soup.select_one('meta[property="og:image"]')
-
 
   if link_title is None or link_description is None or link_site_name is None or link_image is None:
     return
@@ -223,3 +134,18 @@ def get_analysis_results(entity, source):
     }
 
   return response
+
+def get_cached_names():
+  db = mongo_client.ArquivoSentimentos
+
+  query = {"name": { "$exists": True}}
+  fields = { "name": 1, "_id": 0 }
+
+  docs = db.ArquivoSentimentos.find(query, fields)
+
+  cached_names = set()
+  for doc in docs:
+    cached_names.add(doc["name"])
+
+  return list(cached_names)
+

--- a/api/app.py
+++ b/api/app.py
@@ -12,6 +12,11 @@ cors = CORS(app)
 
 sources_urls = {'Correio da Manhã': 'www.cmjornal.pt', 'Jornal de Notícias': 'www.jn.pt', 'Público': 'www.publico.pt'}
 
+@app.route('/cache', methods=['GET'])
+@cross_origin()
+def cache():
+    return { 'names': analysis.get_cached_names()}
+
 @app.route('/results')
 @cross_origin()
 def results():
@@ -27,15 +32,12 @@ def analyse():
     analysis_by_year, magnitude_by_year = analysis.analysis(entity, source)
     return { 'sentiment': { source : analysis_by_year }, 'magnitude': { source : magnitude_by_year } }
 
-
-
 @app.route('/previews')
 @cross_origin()
 def previews():
     entity = request.args.get('entity')
     source = request.args.get('source')
     return {'previews': analysis.get_link_previews(entity, source)}
-
 
 @app.route('/')
 def serve():

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5523,6 +5523,11 @@
         "es6-symbol": "^3.1.1"
       }
     },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+    },
     "es6-symbol": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
@@ -12440,6 +12445,18 @@
         "whatwg-fetch": "^3.4.1"
       }
     },
+    "react-autosuggest": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-autosuggest/-/react-autosuggest-10.1.0.tgz",
+      "integrity": "sha512-/azBHmc6z/31s/lBf6irxPf/7eejQdR0IqnZUzjdSibtlS8+Rw/R79pgDAo6Ft5QqCUTyEQ+f0FhL+1olDQ8OA==",
+      "requires": {
+        "es6-promise": "^4.2.8",
+        "prop-types": "^15.7.2",
+        "react-themeable": "^1.1.0",
+        "section-iterator": "^2.0.0",
+        "shallow-equal": "^1.2.1"
+      }
+    },
     "react-chartjs-2": {
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-2.11.1.tgz",
@@ -12695,6 +12712,21 @@
         "webpack-dev-server": "3.11.1",
         "webpack-manifest-plugin": "2.2.0",
         "workbox-webpack-plugin": "5.1.4"
+      }
+    },
+    "react-themeable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/react-themeable/-/react-themeable-1.1.0.tgz",
+      "integrity": "sha1-fURm3ZsrX6dQWHJ4JenxUro3mg4=",
+      "requires": {
+        "object-assign": "^3.0.0"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+        }
       }
     },
     "react-transition-group": {
@@ -13537,6 +13569,11 @@
         "ajv-keywords": "^3.5.2"
       }
     },
+    "section-iterator": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/section-iterator/-/section-iterator-2.0.0.tgz",
+      "integrity": "sha1-v0RNev7rlK1Dw5rS+yYVFifMuio="
+    },
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -13710,6 +13747,11 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "shallow-equal": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
+      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "i18next-http-backend": "^1.2.1",
     "immutable": "^4.0.0-rc.12",
     "react": "^17.0.1",
+    "react-autosuggest": "^10.1.0",
     "react-chartjs-2": "^2.11.1",
     "react-component-export-image": "^1.0.6",
     "react-csv": "^2.0.3",

--- a/frontend/src/components/InputField.js
+++ b/frontend/src/components/InputField.js
@@ -1,96 +1,19 @@
 import React, { useState } from 'react';
 import Autosuggest from 'react-autosuggest';
 
-const languages = [
-  {
-    name: 'C',
-    year: 1972,
-  },
-  {
-    name: 'C#',
-    year: 2000,
-  },
-  {
-    name: 'C++',
-    year: 1983,
-  },
-  {
-    name: 'Clojure',
-    year: 2007,
-  },
-  {
-    name: 'Elm',
-    year: 2012,
-  },
-  {
-    name: 'Go',
-    year: 2009,
-  },
-  {
-    name: 'Haskell',
-    year: 1990,
-  },
-  {
-    name: 'Java',
-    year: 1995,
-  },
-  {
-    name: 'Javascript',
-    year: 1995,
-  },
-  {
-    name: 'Perl',
-    year: 1987,
-  },
-  {
-    name: 'PHP',
-    year: 1995,
-  },
-  {
-    name: 'Python',
-    year: 1991,
-  },
-  {
-    name: 'Ruby',
-    year: 1995,
-  },
-  {
-    name: 'Scala',
-    year: 2003,
-  },
-];
-
-function escapeRegexCharacters(str) {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-function getSuggestions(value) {
-  const escapedValue = escapeRegexCharacters(value.trim());
-
-  if (escapedValue === '') {
-    return [];
-  }
-
-  const regex = new RegExp('^' + escapedValue, 'i');
-
-  return languages.filter((language) => regex.test(language.name));
-}
-
-function getSuggestionValue(suggestion) {
-  return suggestion.name;
-}
-
-function renderSuggestion(suggestion) {
-  return <span>{suggestion.name}</span>;
-}
-
-const InputField = ({}) => {
+const InputField = ({ cachedEntities, index, handleChange }) => {
   const [value, setValue] = useState('');
 
   const [suggestions, setSuggestions] = useState([]);
 
-  const onChange = (event, { newValue, method }) => {
+  const onChange = (event, { newValue }) => {
+    handleChange(newValue, index);
     setValue(newValue);
+  };
+
+  const onSuggestionSelected = (event, { suggestionValue }) => {
+    handleChange(suggestionValue, index);
+    setValue(suggestionValue);
   };
 
   const onSuggestionsFetchRequested = ({ value }) => {
@@ -99,6 +22,30 @@ const InputField = ({}) => {
 
   const onSuggestionsClearRequested = () => {
     setSuggestions([]);
+  };
+
+  const escapeRegexCharacters = (str) => {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  };
+
+  const getSuggestions = (value) => {
+    const escapedValue = escapeRegexCharacters(value.trim());
+
+    if (escapedValue === '') {
+      return [];
+    }
+
+    const regex = new RegExp('^' + escapedValue, 'i');
+
+    return cachedEntities.filter((language) => regex.test(language.name));
+  };
+
+  const getSuggestionValue = (suggestion) => {
+    return suggestion.name;
+  };
+
+  const renderSuggestion = (suggestion) => {
+    return <span>{suggestion.name}</span>;
   };
 
   const inputProps = {
@@ -112,6 +59,7 @@ const InputField = ({}) => {
       suggestions={suggestions}
       onSuggestionsFetchRequested={onSuggestionsFetchRequested}
       onSuggestionsClearRequested={onSuggestionsClearRequested}
+      onSuggestionSelected={onSuggestionSelected}
       getSuggestionValue={getSuggestionValue}
       renderSuggestion={renderSuggestion}
       inputProps={inputProps}

--- a/frontend/src/components/InputField.js
+++ b/frontend/src/components/InputField.js
@@ -1,11 +1,23 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Autosuggest from 'react-autosuggest';
+import { HiMinusCircle } from 'react-icons/hi';
 import '../styles/Inputs.css';
 
-const InputField = ({ cachedEntities, index, handleChange }) => {
-  const [value, setValue] = useState('');
+const InputField = ({
+  cachedEntities,
+  index,
+  handleChange,
+  handleRemove,
+  name,
+  form,
+}) => {
+  const [value, setValue] = useState(name);
 
   const [suggestions, setSuggestions] = useState([]);
+
+  useEffect(() => {
+    setValue(name);
+  }, [name]);
 
   const onChange = (event, { newValue }) => {
     handleChange(newValue, index);
@@ -56,15 +68,25 @@ const InputField = ({ cachedEntities, index, handleChange }) => {
   };
 
   return (
-    <Autosuggest
-      suggestions={suggestions}
-      onSuggestionsFetchRequested={onSuggestionsFetchRequested}
-      onSuggestionsClearRequested={onSuggestionsClearRequested}
-      onSuggestionSelected={onSuggestionSelected}
-      getSuggestionValue={getSuggestionValue}
-      renderSuggestion={renderSuggestion}
-      inputProps={inputProps}
-    />
+    <>
+      <Autosuggest
+        suggestions={suggestions}
+        onSuggestionsFetchRequested={onSuggestionsFetchRequested}
+        onSuggestionsClearRequested={onSuggestionsClearRequested}
+        onSuggestionSelected={onSuggestionSelected}
+        getSuggestionValue={getSuggestionValue}
+        renderSuggestion={renderSuggestion}
+        inputProps={inputProps}
+      />
+      <HiMinusCircle
+        size={30}
+        id="minus-entity-button"
+        className={form.entities.length === 1 ? 'disabled' : ''}
+        onClick={() => {
+          handleRemove(index);
+        }}
+      />
+    </>
   );
 };
 

--- a/frontend/src/components/InputField.js
+++ b/frontend/src/components/InputField.js
@@ -1,0 +1,122 @@
+import React, { useState } from 'react';
+import Autosuggest from 'react-autosuggest';
+
+const languages = [
+  {
+    name: 'C',
+    year: 1972,
+  },
+  {
+    name: 'C#',
+    year: 2000,
+  },
+  {
+    name: 'C++',
+    year: 1983,
+  },
+  {
+    name: 'Clojure',
+    year: 2007,
+  },
+  {
+    name: 'Elm',
+    year: 2012,
+  },
+  {
+    name: 'Go',
+    year: 2009,
+  },
+  {
+    name: 'Haskell',
+    year: 1990,
+  },
+  {
+    name: 'Java',
+    year: 1995,
+  },
+  {
+    name: 'Javascript',
+    year: 1995,
+  },
+  {
+    name: 'Perl',
+    year: 1987,
+  },
+  {
+    name: 'PHP',
+    year: 1995,
+  },
+  {
+    name: 'Python',
+    year: 1991,
+  },
+  {
+    name: 'Ruby',
+    year: 1995,
+  },
+  {
+    name: 'Scala',
+    year: 2003,
+  },
+];
+
+function escapeRegexCharacters(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function getSuggestions(value) {
+  const escapedValue = escapeRegexCharacters(value.trim());
+
+  if (escapedValue === '') {
+    return [];
+  }
+
+  const regex = new RegExp('^' + escapedValue, 'i');
+
+  return languages.filter((language) => regex.test(language.name));
+}
+
+function getSuggestionValue(suggestion) {
+  return suggestion.name;
+}
+
+function renderSuggestion(suggestion) {
+  return <span>{suggestion.name}</span>;
+}
+
+const InputField = ({}) => {
+  const [value, setValue] = useState('');
+
+  const [suggestions, setSuggestions] = useState([]);
+
+  const onChange = (event, { newValue, method }) => {
+    setValue(newValue);
+  };
+
+  const onSuggestionsFetchRequested = ({ value }) => {
+    setSuggestions(getSuggestions(value));
+  };
+
+  const onSuggestionsClearRequested = () => {
+    setSuggestions([]);
+  };
+
+  const inputProps = {
+    placeholder: '',
+    value,
+    onChange: onChange,
+  };
+
+  return (
+    <Autosuggest
+      suggestions={suggestions}
+      onSuggestionsFetchRequested={onSuggestionsFetchRequested}
+      onSuggestionsClearRequested={onSuggestionsClearRequested}
+      getSuggestionValue={getSuggestionValue}
+      renderSuggestion={renderSuggestion}
+      inputProps={inputProps}
+    />
+  );
+};
+
+export default InputField;

--- a/frontend/src/components/InputField.js
+++ b/frontend/src/components/InputField.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import Autosuggest from 'react-autosuggest';
+import '../styles/Inputs.css';
 
 const InputField = ({ cachedEntities, index, handleChange }) => {
   const [value, setValue] = useState('');

--- a/frontend/src/components/Main.js
+++ b/frontend/src/components/Main.js
@@ -12,6 +12,7 @@ import SentimentChart from './SentimentChart';
 import ExportModal from './ExportModal';
 import { withTranslation } from 'react-i18next';
 import News from './News';
+import InputField from './InputField';
 import { Set } from 'immutable';
 
 const newsSources = ['Correio da Manhã', 'Jornal de Notícias', 'Público'];
@@ -252,6 +253,7 @@ function Main({ t, examples, setExamples }) {
     form.entities.forEach((value, i) => {
       entitiesElements.push(
         <div className="d-flex" key={i}>
+          <InputField />
           <Input
             type="text"
             name="entity"

--- a/frontend/src/components/Main.js
+++ b/frontend/src/components/Main.js
@@ -43,6 +43,14 @@ function Main({ t, examples, setExamples }) {
   const scoreCardRef = createRef();
   const magnitudeCardRef = createRef();
 
+  const [cachedEntities, setCachedEntities] = useState([]);
+
+  useEffect(() => {
+    axios.get(`${process.env.REACT_APP_PROXY}/cache`).then((res) => {
+      setCachedEntities(res.data.names);
+    });
+  }, []);
+
   useEffect(() => {
     const interval = setInterval(() => {
       requestPendingQueries();
@@ -92,11 +100,11 @@ function Main({ t, examples, setExamples }) {
   };
 
   const requestPendingQueries = () => {
-    console.log("Pending " + pendingQueries.size + " requests");
+    console.log('Pending ' + pendingQueries.size + ' requests');
     for (let el of pendingQueries) {
       requestAnalysis(el.entity, el.source, true);
     }
-  }
+  };
 
   const requestNews = (entity, source) => {
     axios
@@ -126,31 +134,30 @@ function Main({ t, examples, setExamples }) {
       });
   };
 
-  const requestAnalysis = (entity, source, isPending=false) => {
+  const requestAnalysis = (entity, source, isPending = false) => {
     let params = { entity, source };
 
-    if (!isPending){
+    if (!isPending) {
       setLoadingSources((prev) => {
         let current = Object.assign({}, prev);
         current[source] += 1;
         return current;
       });
-    }    
+    }
 
     axios
       .get(`${process.env.REACT_APP_PROXY}/results`, { params })
       .then((res) => {
         if (res.data.status == 'ON_CACHE') {
-
           setSentimentScores((current) => {
             let st = { ...current };
             let st_en = { ...st[entity] };
             st_en[source] = res.data.content.sentiment[source];
             st[entity] = st_en;
-  
+
             return st;
           });
-  
+
           setMagnitudeScores((current) => {
             let st = { ...current };
             let st_en = { ...st[entity] };
@@ -158,20 +165,30 @@ function Main({ t, examples, setExamples }) {
             st[entity] = st_en;
             return st;
           });
-  
+
           setLoadingSources((prev) => {
             let current = Object.assign({}, prev);
             current[source] -= 1;
             return current;
           });
 
-          if (isPending){
-            setPendingQueries((prev) => new Set([...prev].filter((x) => (x.entity !== entity || x.source !== source))));
+          if (isPending) {
+            setPendingQueries(
+              (prev) =>
+                new Set(
+                  [...prev].filter(
+                    (x) => x.entity !== entity || x.source !== source
+                  )
+                )
+            );
           }
           requestNews(entity, source);
-        } else if (res.data.status == 'NOT_ON_CACHE'){
-          if (!isPending){
-            setPendingQueries((prev) => new Set(prev.add({'entity': entity, 'source': source})));
+        } else if (res.data.status == 'NOT_ON_CACHE') {
+          if (!isPending) {
+            setPendingQueries(
+              (prev) =>
+                new Set(prev.add({ 'entity': entity, 'source': source }))
+            );
           }
         }
       });
@@ -184,7 +201,7 @@ function Main({ t, examples, setExamples }) {
       return null;
     });
     setSelectedEntity(null);
-    setPendingQueries(new Set())
+    setPendingQueries(new Set());
     setLoadingSources({
       'Correio da Manhã': 0,
       'Jornal de Notícias': 0,

--- a/frontend/src/components/Main.js
+++ b/frontend/src/components/Main.js
@@ -89,13 +89,20 @@ function Main({ t, examples, setExamples }) {
   };
 
   const handleRemove = (i) => {
-    console.log(i);
     if (form.entities.length <= 1) return;
-    const filteredEntites = form.entities.filter((el, elI) => elI !== i);
-    console.log(filteredEntites);
-    setQueryEntities(new Set([...filteredEntites]));
+    const filteredEntitiesList = form.entities.filter((el, elI) => elI !== i);
+    const filteredEntitiesSet = new Set([...filteredEntitiesList]);
+    setQueryEntities(filteredEntitiesSet);
     setForm({
-      entities: filteredEntites,
+      entities: filteredEntitiesList,
+    });
+    setPreviews((previews) => {
+      for (let entity in previews) {
+        if (!filteredEntitiesSet.has(entity)) {
+          delete previews[entity];
+        }
+      }
+      return previews;
     });
   };
 

--- a/frontend/src/components/Main.js
+++ b/frontend/src/components/Main.js
@@ -250,28 +250,12 @@ function Main({ t, examples, setExamples }) {
     const entitiesElements = [];
     form.entities.forEach((value, i) => {
       entitiesElements.push(
-        <div className="d-flex" key={i}>
+        <div className="input-container" key={i}>
           <InputField
             cachedEntities={cachedEntities}
             index={i}
             handleChange={handleChange}
           />
-          {/* <Input
-            type="text"
-            name="entity"
-            className="entity-name"
-            placeholder="Write your entity in here"
-            value={value}
-            onChange={(e) => {
-              handleChange(e, i);
-            }}
-            onKeyPress={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault();
-                handleSubmit();
-              }
-            }}
-          /> */}
           <HiMinusCircle
             size={30}
             id="minus-entity-button"

--- a/frontend/src/components/Main.js
+++ b/frontend/src/components/Main.js
@@ -100,6 +100,9 @@ function Main({ t, examples, setExamples }) {
       for (let entity in previews) {
         if (!filteredEntitiesSet.has(entity)) {
           delete previews[entity];
+          if (selectedEntity === entity) {
+            setSelectedEntity(filteredEntitiesList[0]);
+          }
         }
       }
       return previews;

--- a/frontend/src/components/Main.js
+++ b/frontend/src/components/Main.js
@@ -76,11 +76,9 @@ function Main({ t, examples, setExamples }) {
     }
   }, [form]);
 
-  const handleChange = (e, i) => {
+  const handleChange = (value, i) => {
     setForm({
-      entities: form.entities.map((el, elI) =>
-        elI === i ? e.target.value : el
-      ),
+      entities: form.entities.map((el, elI) => (elI === i ? value : el)),
     });
   };
 
@@ -253,8 +251,12 @@ function Main({ t, examples, setExamples }) {
     form.entities.forEach((value, i) => {
       entitiesElements.push(
         <div className="d-flex" key={i}>
-          <InputField />
-          <Input
+          <InputField
+            cachedEntities={cachedEntities}
+            index={i}
+            handleChange={handleChange}
+          />
+          {/* <Input
             type="text"
             name="entity"
             className="entity-name"
@@ -269,7 +271,7 @@ function Main({ t, examples, setExamples }) {
                 handleSubmit();
               }
             }}
-          />
+          /> */}
           <HiMinusCircle
             size={30}
             id="minus-entity-button"

--- a/frontend/src/components/Main.js
+++ b/frontend/src/components/Main.js
@@ -4,7 +4,7 @@ import {
   exportComponentAsJPEG,
   exportComponentAsPDF,
 } from 'react-component-export-image';
-import { HiMinusCircle, HiPlusCircle } from 'react-icons/hi';
+import { HiPlusCircle } from 'react-icons/hi';
 import { BiDownload, BiInfoCircle } from 'react-icons/bi';
 import axios from 'axios';
 import YearsRange from './YearsRange';
@@ -89,12 +89,13 @@ function Main({ t, examples, setExamples }) {
   };
 
   const handleRemove = (i) => {
+    console.log(i);
     if (form.entities.length <= 1) return;
-    setQueryEntities(
-      new Set([...form.entities.filter((el, elI) => elI !== i)])
-    );
+    const filteredEntites = form.entities.filter((el, elI) => elI !== i);
+    console.log(filteredEntites);
+    setQueryEntities(new Set([...filteredEntites]));
     setForm({
-      entities: form.entities.filter((el, elI) => elI !== i),
+      entities: filteredEntites,
     });
   };
 
@@ -212,11 +213,13 @@ function Main({ t, examples, setExamples }) {
     clearOutputs();
     setQueryEntities(new Set([...form.entities]));
 
-    form.entities.forEach((entity) => {
-      sources.forEach((source) => {
-        requestAnalysis(entity, source);
+    form.entities
+      .filter((entity) => entity !== '')
+      .forEach((entity) => {
+        sources.forEach((source) => {
+          requestAnalysis(entity, source);
+        });
       });
-    });
   };
 
   const toggleSource = (source) => {
@@ -255,14 +258,9 @@ function Main({ t, examples, setExamples }) {
             cachedEntities={cachedEntities}
             index={i}
             handleChange={handleChange}
-          />
-          <HiMinusCircle
-            size={30}
-            id="minus-entity-button"
-            className={form.entities.length === 1 ? 'disabled' : ''}
-            onClick={() => {
-              handleRemove(i);
-            }}
+            handleRemove={handleRemove}
+            name={value}
+            form={form}
           />
         </div>
       );

--- a/frontend/src/styles/App.css
+++ b/frontend/src/styles/App.css
@@ -8,7 +8,7 @@
   --danger: #ff0000;
   --accent: #0346f2;
   --light-accent: #f2f5fe;
-  --primary-font: 'Source Sans Pro', Arial, sans-serif;
+  --primary-font: 'Poppins', Arial, sans-serif;
 }
 
 *,
@@ -239,25 +239,6 @@ strong {
   font-weight: 500;
 }
 
-input.entity-name {
-  border: none;
-  padding: 1.5rem 0.2rem;
-  margin-bottom: 0.5rem;
-  border-bottom: 1px solid var(--light-gray);
-  color: var(--gray);
-  font-size: 14px;
-  line-height: 24px;
-  background-color: #fff !important;
-}
-
-input.entity-name:-internal-autofill-selected {
-  background-color: #fff !important;
-}
-
-input.entity-name::placeholder {
-  color: var(--light-gray);
-}
-
 #search-button,
 #confirm-export-button {
   width: 100%;
@@ -479,62 +460,4 @@ input.entity-name::placeholder {
 
 ::-webkit-scrollbar-thumb:hover {
   background: #8e94a7;
-}
-
-.react-autosuggest__container {
-  position: relative;
-}
-
-.react-autosuggest__input {
-  width: 240px;
-  height: 30px;
-  padding: 10px 20px;
-  font-family: Helvetica, sans-serif;
-  font-weight: 300;
-  font-size: 16px;
-  border: 1px solid #aaa;
-  border-radius: 4px;
-}
-
-.react-autosuggest__input--focused {
-  outline: none;
-}
-
-.react-autosuggest__input--open {
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-}
-
-.react-autosuggest__suggestions-container {
-  display: none;
-}
-
-.react-autosuggest__suggestions-container--open {
-  display: block;
-  position: absolute;
-  top: 51px;
-  width: 280px;
-  border: 1px solid #aaa;
-  background-color: #fff;
-  font-family: Helvetica, sans-serif;
-  font-weight: 300;
-  font-size: 16px;
-  border-bottom-left-radius: 4px;
-  border-bottom-right-radius: 4px;
-  z-index: 2;
-}
-
-.react-autosuggest__suggestions-list {
-  margin: 0;
-  padding: 0;
-  list-style-type: none;
-}
-
-.react-autosuggest__suggestion {
-  cursor: pointer;
-  padding: 10px 20px;
-}
-
-.react-autosuggest__suggestion--highlighted {
-  background-color: #ddd;
 }

--- a/frontend/src/styles/App.css
+++ b/frontend/src/styles/App.css
@@ -480,3 +480,61 @@ input.entity-name::placeholder {
 ::-webkit-scrollbar-thumb:hover {
   background: #8e94a7;
 }
+
+.react-autosuggest__container {
+  position: relative;
+}
+
+.react-autosuggest__input {
+  width: 240px;
+  height: 30px;
+  padding: 10px 20px;
+  font-family: Helvetica, sans-serif;
+  font-weight: 300;
+  font-size: 16px;
+  border: 1px solid #aaa;
+  border-radius: 4px;
+}
+
+.react-autosuggest__input--focused {
+  outline: none;
+}
+
+.react-autosuggest__input--open {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.react-autosuggest__suggestions-container {
+  display: none;
+}
+
+.react-autosuggest__suggestions-container--open {
+  display: block;
+  position: absolute;
+  top: 51px;
+  width: 280px;
+  border: 1px solid #aaa;
+  background-color: #fff;
+  font-family: Helvetica, sans-serif;
+  font-weight: 300;
+  font-size: 16px;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+  z-index: 2;
+}
+
+.react-autosuggest__suggestions-list {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+}
+
+.react-autosuggest__suggestion {
+  cursor: pointer;
+  padding: 10px 20px;
+}
+
+.react-autosuggest__suggestion--highlighted {
+  background-color: #ddd;
+}

--- a/frontend/src/styles/Inputs.css
+++ b/frontend/src/styles/Inputs.css
@@ -1,0 +1,93 @@
+.input-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.react-autosuggest__container {
+  flex-grow: 1;
+}
+
+input.react-autosuggest__input {
+  width: 100%;
+  border: none;
+  padding: 1.5rem 0.2rem;
+  margin-bottom: 0.5rem;
+  border-bottom: 1px solid var(--light-gray);
+  color: var(--gray);
+  background-color: #fff !important;
+  font-family: var(--primary-font);
+  font-size: 14px;
+  line-height: 24px;
+  font-weight: 400;
+}
+
+input.react-autosuggest__input:-internal-autofill-selected {
+  background-color: #fff !important;
+}
+
+input.react-autosuggest__input::placeholder {
+  color: var(--light-gray);
+}
+
+.react-autosuggest__suggestions-list {
+  margin: 0;
+  padding: 0.5rem 0;
+  list-style-type: none;
+}
+
+.react-autosuggest__suggestion {
+  cursor: pointer;
+  padding: 10px 20px;
+  color: #16181b;
+  font-size: 15px;
+  font: 14px var(--primary-font);
+}
+
+.react-autosuggest__suggestion--highlighted {
+  background-color: #e9ecef;
+}
+
+.react-autosuggest__container {
+  position: relative;
+}
+
+.react-autosuggest__input {
+  width: 240px;
+  height: 30px;
+  padding: 10px 20px;
+  font-family: Helvetica, sans-serif;
+  font-weight: 300;
+  font-size: 16px;
+  border: 1px solid #aaa;
+  border-radius: 4px;
+}
+
+.react-autosuggest__input--focused {
+  outline: none;
+}
+
+.react-autosuggest__input--open {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.react-autosuggest__suggestions-container {
+  display: none;
+}
+
+.react-autosuggest__suggestions-container--open {
+  display: block;
+  position: absolute;
+  border-radius: 5px;
+  top: 48px;
+  width: 100%;
+  border: 1px solid #aaa;
+  background-color: #fff;
+  font-family: Helvetica, sans-serif;
+  font-weight: 300;
+  font-size: 16px;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+  z-index: 2;
+}

--- a/frontend/src/styles/Inputs.css
+++ b/frontend/src/styles/Inputs.css
@@ -34,6 +34,8 @@ input.react-autosuggest__input::placeholder {
   margin: 0;
   padding: 0.5rem 0;
   list-style-type: none;
+  max-height: 260px;
+  overflow-y: auto;
 }
 
 .react-autosuggest__suggestion {


### PR DESCRIPTION
## Changes

When a user searches for an entity, it has not a set of suggestions that show the cached results on our database, allowing the user to easily know what is cached or not. The search inputs also allow for auto-completion with these cached entities:
![image](https://user-images.githubusercontent.com/41621540/117293071-db0fa700-ae68-11eb-9819-c3e71c7c185e.png)

I also took the chance to fix some front-end bugs, the most important being the fact that when an entity was removed, its previews kept showing unless the user clicked the "Confirm" button. It should be fixed by now!

Closes #6 